### PR TITLE
ci: update workflow to use check target and add debug steps

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -15,11 +15,13 @@ jobs:
             os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v4
+    - name: Debugging Log
+      run: |
+        make clean --debug=v SHELL='sh -xvp'
+    - name: Target Log
+      run: |
+        make -p
     - name: Run check
       run: |
         make clean
         make check
-    - name: Run test
-      run: |
-        make clean
-        make test


### PR DESCRIPTION
- Remove obsolete 'make test' step (target was renamed to 'check')
- Add debugging log step with verbose Make output
- Add target log step to show Make's internal state
- Align with bowerbird-core workflow structure