### PR TITLE
fix: correct word wrap alignment for multi-line descriptions

### DIFF
--- a/src/bowerbird-help/bowerbird-help.mk
+++ b/src/bowerbird-help/bowerbird-help.mk
@@ -109,7 +109,7 @@ function wrap_text(text, width, indent,    words, n, line, i, word, result, firs
 	if (target !~ /^--/ && "$(1)" != "targets") \
 		next; \
 	indent = ""; \
-	for (i = 0; i < target_width + 2; i++) \
+	for (i = 0; i < target_width + 3; i++) \
 		indent = indent " "; \
 	wrapped = wrap_text(desc, desc_width, indent); \
 	if (wrapped == "") { \

--- a/test/bowerbird-help/test-formatting-long.mk
+++ b/test/bowerbird-help/test-formatting-long.mk
@@ -11,7 +11,7 @@ define expected-formatting-long
 
 Available targets:
   \033[38;5;179mmock-formatting-long     \033[0m This is a very long description that should wrap at the
-                           configured width maintaining proper alignment
+                            configured width maintaining proper alignment
 
 Optional flags:
 

--- a/test/bowerbird-help/test-formatting-multiple-lines.mk
+++ b/test/bowerbird-help/test-formatting-multiple-lines.mk
@@ -11,9 +11,9 @@ define expected-formatting-multiple-lines
 
 Available targets:
   \033[38;5;179mmock-formatting-multiple-lines\033[0m This is an extremely long description that will require
-                           exceeds the configured maximum description width by a
-                           multiple line wraps to display properly because it
-                           significant amount
+                            exceeds the configured maximum description width by a
+                            multiple line wraps to display properly because it
+                            significant amount
 
 Optional flags:
 


### PR DESCRIPTION
The wrapped continuation lines were misaligned by one space to the left. This fix changes the indent calculation from target_width + 2 to target_width + 3 to properly account for:
- 2 spaces at the start of each line
- The target column width
- 1 space between target and description

Updated test expectations in test-formatting-long and test-formatting-multiple-lines to match the corrected alignment.

Before:
  target-name              Description text that wraps
                           continuation line (off by 1)

After:
  target-name              Description text that wraps
                            continuation line (aligned)