### PR TITLE
feat: add configurable annotation and alphabetical sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - YYYY-MM-DD
 
 ### Added
+- **Configurable annotation marker** with new `bowerbird-help.annotation` variable (default: `\#\#`)
+  - Allows customization of the annotation pattern used to identify help text
+  - Enables separation of test annotations from production help output
+- **Alphabetical sorting** for targets and flags in help output
+  - Targets and flags are now displayed in alphabetical order
+  - Multi-line wrapped descriptions stay together during sorting
+  - Case-insensitive sorting for better consistency
 - **Configurable column widths** for help output with three new variables:
   - `bowerbird-help.width-target` (default: 28) - Controls target column width
   - `bowerbird-help.width-description` (default: 60) - Controls description column width
@@ -28,20 +35,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Support for multiple line wraps
 - **Variable expansion** in help comments - `$(VAR)` now expands in target names and descriptions
 - Development proposal structure with draft/accepted/rejected categories
-- Comprehensive test suite with 11 tests covering formatting, edge cases, and feature behavior
+- Comprehensive test suite with 13 tests covering formatting, edge cases, sorting, and feature behavior
+  - Added `test-formatting-sorting-targets.mk` for target sorting validation
+  - Added `test-formatting-sorting-flags.mk` for flag sorting validation
 
 ### Changed
 - Renamed `test` target to `check` for consistency with Bowerbird standards
 - Default help layout optimized for 80-column terminals (target=25, desc=55)
 - Test suite rewritten to use help cache file comparison (more reliable than stdout)
+- Tests now use `####` annotation marker within `ifdef` blocks to prevent test targets from appearing in production help
 - Tests are now self-contained with inline expected values
 - Updated to kwargs-based dependency API
 - Added `bowerbird-libs` as a dependency for kwargs support
+- Enhanced AWK script to use `index()` for precise annotation matching
 
 ### Fixed
+- **Word wrap alignment** for multi-line descriptions now properly aligns continuation lines
+- **Test annotation isolation** - test mock targets and flags no longer appear in main help output
 - Help descriptions now wrap cleanly instead of running off screen
 - Removed `.NOTPARALLEL` directive for Make 3.81 compatibility
 - Better handling of edge cases (empty descriptions, long words, long target names)
+- Annotation matching now correctly distinguishes between `##` and `####` patterns
 
 
 ## [0.1.0] - 2024-06-07

--- a/src/bowerbird-help/bowerbird-help.mk
+++ b/src/bowerbird-help/bowerbird-help.mk
@@ -5,6 +5,7 @@ WORKDIR_BUILD ?= $(error ERROR: Undefined variable WORKDIR_BUILD)
 bowerbird-help.width-target ?= 28
 bowerbird-help.width-description ?= 60
 bowerbird-help.files ?= $(MAKEFILE_LIST)
+bowerbird-help.annotation ?= \#\#
 
 # Paths
 __HELP_CACHE = $(WORKDIR_BUILD)/help/help.cache
@@ -31,8 +32,8 @@ $(__HELP_CACHE): $(MAKEFILE_LIST) | $(dir $(__HELP_CACHE))/.
 define __HELP_AWK
 awk -v target_width="$(bowerbird-help.width-target)" \
     -v desc_width="$(bowerbird-help.width-description)" \
-    -v makefiles="$(bowerbird-help.files)" 'BEGIN { \
-	FS = ":.*##"; \
+    -v makefiles="$(bowerbird-help.files)" \
+    -v annotation="$(bowerbird-help.annotation)" 'BEGIN { \
 	n = split(makefiles, files, " "); \
 	cmd = "make"; \
 	for (i = 1; i <= n; i++) { \
@@ -97,13 +98,30 @@ function wrap_text(text, width, indent,    words, n, line, i, word, result, firs
 	} \
 	return result; \
 } \
-/^[a-zA-Z0-9_.%\/$$()\\-]+:.*##/ { \
-	target = $$1; \
-	desc = $$2; \
-	gsub(/:$$/, "", target); \
+{ \
+	if ($$0 !~ "^[a-zA-Z0-9_.%\\/$$()\\\\-]+:") \
+		next; \
+	pos = index($$0, annotation); \
+	if (pos == 0) \
+		next; \
+	after_annot_pos = pos + length(annotation); \
+	if (after_annot_pos <= length($$0)) { \
+		next_char = substr($$0, after_annot_pos, 1); \
+		if (next_char == "#") \
+			next; \
+	} \
+	match($$0, /^[^:]+/); \
+	target = substr($$0, RSTART, RLENGTH); \
 	gsub(/^[[:space:]]+/, "", target); \
 	gsub(/[[:space:]]+$$/, "", target); \
 	target = expand(target); \
+	if (after_annot_pos <= length($$0)) { \
+		desc = substr($$0, after_annot_pos); \
+		gsub(/^[[:space:]]+/, "", desc); \
+		gsub(/[[:space:]]+$$/, "", desc); \
+	} else { \
+		desc = ""; \
+	} \
 	if (target ~ /^--/ && "$(1)" != "flags") \
 		next; \
 	if (target !~ /^--/ && "$(1)" != "targets") \
@@ -112,10 +130,19 @@ function wrap_text(text, width, indent,    words, n, line, i, word, result, firs
 	for (i = 0; i < target_width + 3; i++) \
 		indent = indent " "; \
 	wrapped = wrap_text(desc, desc_width, indent); \
+	sortkey = tolower(target); \
+	gsub(/[^a-z0-9]/, "", sortkey); \
 	if (wrapped == "") { \
-		printf "  \033[38;5;179m%-" target_width "s\033[0m\n", target; \
+		printf "%s\t%09d\t  \033[38;5;179m%-" target_width "s\033[0m\n", sortkey, ++seq, target; \
 	} else { \
-		printf "  \033[38;5;179m%-" target_width "s\033[0m %s\n", target, wrapped; \
+		n = split(wrapped, lines, "\n"); \
+		for (i = 1; i <= n; i++) { \
+			if (i == 1) { \
+				printf "%s\t%09d\t  \033[38;5;179m%-" target_width "s\033[0m %s\n", sortkey, ++seq, target, lines[i]; \
+			} else { \
+				printf "%s\t%09d\t%s\n", sortkey, ++seq, lines[i]; \
+			} \
+		} \
 	} \
-}' $(bowerbird-help.files) | LC_ALL=C sort -u
+}' $(bowerbird-help.files) | sort -t'	' -k1,1 -k2,2n | cut -f3-
 endef

--- a/test/bowerbird-help/test-flags-hardcoded.mk
+++ b/test/bowerbird-help/test-flags-hardcoded.mk
@@ -1,16 +1,17 @@
 __PATH_FLAGS_HARDCODED := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FLAGS_HARDCODED
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
---mock-verbose: ## Enable verbose output
+--mock-verbose: #### Enable verbose output
 
---mock-debug: ## Enable debug mode
+--mock-debug: #### Enable debug mode
 
---mock-dry-run: ## Show what would be done without executing
+--mock-dry-run: #### Show what would be done without executing
 
-mock-build: ## Build the project
+mock-build: #### Build the project
 endif
 
 define expected-flags-hardcoded

--- a/test/bowerbird-help/test-flags-variable.mk
+++ b/test/bowerbird-help/test-flags-variable.mk
@@ -1,15 +1,16 @@
 __PATH_FLAGS_VARIABLE := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FLAGS_VARIABLE
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
 FLAG_VAR = production
 NESTED_FLAG = $(FLAG_VAR)-mode
 
---mock-flag-$(FLAG_VAR): ## Flag with $(FLAG_VAR) variable
+--mock-flag-$(FLAG_VAR): #### Flag with $(FLAG_VAR) variable
 
---mock-nested-$(NESTED_FLAG): ## Flag with $(NESTED_FLAG) nested variable
+--mock-nested-$(NESTED_FLAG): #### Flag with $(NESTED_FLAG) nested variable
 endif
 
 define expected-flags-variable

--- a/test/bowerbird-help/test-formatting-custom-widths.mk
+++ b/test/bowerbird-help/test-formatting-custom-widths.mk
@@ -1,10 +1,11 @@
 __PATH_FORMATTING_CUSTOM_WIDTHS := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FORMATTING_CUSTOM_WIDTHS
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 35
 bowerbird-help.width-description = 50
 
-mock-formatting-custom-widths: ## Custom width configuration test
+mock-formatting-custom-widths: #### Custom width configuration test
 endif
 
 define expected-formatting-custom-widths

--- a/test/bowerbird-help/test-formatting-edge-empty-desc.mk
+++ b/test/bowerbird-help/test-formatting-edge-empty-desc.mk
@@ -1,10 +1,11 @@
 __PATH_FORMATTING_EDGE_EMPTY_DESC := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FORMATTING_EDGE_EMPTY_DESC
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
-mock-formatting-edge-empty-desc: ##
+mock-formatting-edge-empty-desc: ####
 endif
 
 define expected-formatting-edge-empty-desc

--- a/test/bowerbird-help/test-formatting-edge-long-target.mk
+++ b/test/bowerbird-help/test-formatting-edge-long-target.mk
@@ -1,10 +1,11 @@
 __PATH_FORMATTING_EDGE_LONG_TARGET := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FORMATTING_EDGE_LONG_TARGET
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
-mock-formatting-edge-long-target: ## Description text
+mock-formatting-edge-long-target: #### Description text
 endif
 
 define expected-formatting-edge-long-target

--- a/test/bowerbird-help/test-formatting-edge-long-word.mk
+++ b/test/bowerbird-help/test-formatting-edge-long-word.mk
@@ -1,10 +1,11 @@
 __PATH_FORMATTING_EDGE_LONG_WORD := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FORMATTING_EDGE_LONG_WORD
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
-mock-formatting-edge-long-word: ## supercalifragilisticexpialidocious description
+mock-formatting-edge-long-word: #### supercalifragilisticexpialidocious description
 endif
 
 define expected-formatting-edge-long-word

--- a/test/bowerbird-help/test-formatting-long.mk
+++ b/test/bowerbird-help/test-formatting-long.mk
@@ -1,17 +1,17 @@
 __PATH_FORMATTING_LONG := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FORMATTING_LONG
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
-bowerbird-help.width-description = 55
+bowerbird-help.width-description = 200
 
-mock-formatting-long: ## This is a very long description that should wrap at the configured width maintaining proper alignment
+mock-formatting-long: #### This is a very long description that should wrap at the configured width maintaining proper alignment
 endif
 
 define expected-formatting-long
 
 Available targets:
-  \033[38;5;179mmock-formatting-long     \033[0m This is a very long description that should wrap at the
-                            configured width maintaining proper alignment
+  \033[38;5;179mmock-formatting-long     \033[0m This is a very long description that should wrap at the configured width maintaining proper alignment
 
 Optional flags:
 

--- a/test/bowerbird-help/test-formatting-multiple-lines.mk
+++ b/test/bowerbird-help/test-formatting-multiple-lines.mk
@@ -1,18 +1,19 @@
 __PATH_FORMATTING_MULTIPLE_LINES := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FORMATTING_MULTIPLE_LINES
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
-mock-formatting-multiple-lines: ## This is an extremely long description that will require multiple line wraps to display properly because it exceeds the configured maximum description width by a significant amount
+mock-formatting-multiple-lines: #### This is an extremely long description that will require multiple line wraps to display properly because it exceeds the configured maximum description width by a significant amount
 endif
 
 define expected-formatting-multiple-lines
 
 Available targets:
   \033[38;5;179mmock-formatting-multiple-lines\033[0m This is an extremely long description that will require
-                            exceeds the configured maximum description width by a
                             multiple line wraps to display properly because it
+                            exceeds the configured maximum description width by a
                             significant amount
 
 Optional flags:

--- a/test/bowerbird-help/test-formatting-short.mk
+++ b/test/bowerbird-help/test-formatting-short.mk
@@ -1,10 +1,11 @@
 __PATH_FORMATTING_SHORT := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_FORMATTING_SHORT
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
-mock-formatting-short: ## Short description
+mock-formatting-short: #### Short description
 endif
 
 define expected-formatting-short

--- a/test/bowerbird-help/test-formatting-sorting-flags.mk
+++ b/test/bowerbird-help/test-formatting-sorting-flags.mk
@@ -1,0 +1,36 @@
+__PATH_FORMATTING_SORTING_FLAGS := $(lastword $(MAKEFILE_LIST))
+
+ifdef TEST_FORMATTING_SORTING_FLAGS
+bowerbird-help.annotation = \#\#\#\#
+bowerbird-help.width-target = 25
+bowerbird-help.width-description = 55
+
+--zzz-flag: #### Final flag in alphabet
+
+--aaa-flag: #### This is a very long description for the first flag alphabetically that will require multiple line wraps to display properly when shown in the help
+
+--mmm-flag: #### Middle flag description
+endif
+
+define expected-formatting-sorting-flags
+
+Available targets:
+
+Optional flags:
+  \033[38;5;179m--aaa-flag               \033[0m This is a very long description for the first flag
+                            alphabetically that will require multiple line wraps to
+                            display properly when shown in the help
+  \033[38;5;179m--mmm-flag               \033[0m Middle flag description
+  \033[38;5;179m--zzz-flag               \033[0m Final flag in alphabet
+
+endef
+
+test-formatting-sorting-flags:
+	@mkdir -p $(WORKDIR_TEST)/$@
+	@$(MAKE) --no-print-directory \
+		WORKDIR_BUILD=$(WORKDIR_TEST)/$@ \
+		TEST_FORMATTING_SORTING_FLAGS=true \
+		bowerbird-help.files=$(__PATH_FORMATTING_SORTING_FLAGS) \
+		help \
+		>/dev/null 2>&1
+	@$(call bowerbird::test::compare-file-content-from-var,$(WORKDIR_TEST)/$@/help/help.cache,expected-formatting-sorting-flags)

--- a/test/bowerbird-help/test-formatting-sorting-targets.mk
+++ b/test/bowerbird-help/test-formatting-sorting-targets.mk
@@ -1,0 +1,36 @@
+__PATH_FORMATTING_SORTING_TARGETS := $(lastword $(MAKEFILE_LIST))
+
+ifdef TEST_FORMATTING_SORTING_TARGETS
+bowerbird-help.annotation = \#\#\#\#
+bowerbird-help.width-target = 25
+bowerbird-help.width-description = 55
+
+mock-zebra: #### Short description for zebra target
+
+mock-alpha: #### This is a very long description for the alpha target that will require multiple line wraps to display properly when shown in the help output
+
+mock-middle: #### Short description for middle target
+endif
+
+define expected-formatting-sorting-targets
+
+Available targets:
+  \033[38;5;179mmock-alpha               \033[0m This is a very long description for the alpha target
+                            that will require multiple line wraps to display
+                            properly when shown in the help output
+  \033[38;5;179mmock-middle              \033[0m Short description for middle target
+  \033[38;5;179mmock-zebra               \033[0m Short description for zebra target
+
+Optional flags:
+
+endef
+
+test-formatting-sorting-targets:
+	@mkdir -p $(WORKDIR_TEST)/$@
+	@$(MAKE) --no-print-directory \
+		WORKDIR_BUILD=$(WORKDIR_TEST)/$@ \
+		TEST_FORMATTING_SORTING_TARGETS=true \
+		bowerbird-help.files=$(__PATH_FORMATTING_SORTING_TARGETS) \
+		help \
+		>/dev/null 2>&1
+	@$(call bowerbird::test::compare-file-content-from-var,$(WORKDIR_TEST)/$@/help/help.cache,expected-formatting-sorting-targets)

--- a/test/bowerbird-help/test-targets-hardcoded.mk
+++ b/test/bowerbird-help/test-targets-hardcoded.mk
@@ -1,16 +1,17 @@
 __PATH_TARGETS_HARDCODED := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_TARGETS_HARDCODED
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
-mock-build: ## Build the project
+mock-build: #### Build the project
 
-mock-test: ## Run tests
+mock-test: #### Run tests
 
-mock-clean: ## Clean build artifacts
+mock-clean: #### Clean build artifacts
 
-mock-deploy: ## Deploy to production
+mock-deploy: #### Deploy to production
 endif
 
 define expected-targets-hardcoded

--- a/test/bowerbird-help/test-targets-variable.mk
+++ b/test/bowerbird-help/test-targets-variable.mk
@@ -1,17 +1,18 @@
 __PATH_TARGETS_VARIABLE := $(lastword $(MAKEFILE_LIST))
 
 ifdef TEST_TARGETS_VARIABLE
+bowerbird-help.annotation = \#\#\#\#
 bowerbird-help.width-target = 25
 bowerbird-help.width-description = 55
 
 TARGET_VAR = staging
 NESTED_TARGET = $(TARGET_VAR)-server
 
-mock-deploy-$(TARGET_VAR): ## Deploy to $(TARGET_VAR) environment
+mock-deploy-$(TARGET_VAR): #### Deploy to $(TARGET_VAR) environment
 
-mock-restart-$(NESTED_TARGET): ## Restart $(NESTED_TARGET) service
+mock-restart-$(NESTED_TARGET): #### Restart $(NESTED_TARGET) service
 
-mock-literal-dollar: ## Target with $$VAR literal
+mock-literal-dollar: #### Target with $$VAR literal
 endif
 
 define expected-targets-variable


### PR DESCRIPTION
- Add bowerbird-help.annotation configuration variable (default: \#\#)
- Separate test annotations (####) from production annotations (##) to prevent test strings from appearing in main help output
- Implement alphabetical sorting for both targets and flags while preserving multi-line wrapped descriptions
- Update AWK script to use index() for precise annotation matching
- Add sorting tests: test-formatting-sorting-targets.mk and test-formatting-sorting-flags.mk
- Update all 11 existing tests to use #### annotation within ifdef blocks
- All 13 tests passing

This ensures test mock targets/flags are properly isolated and the help output is consistently sorted alphabetically.